### PR TITLE
Fixed package.json (removed invalid afterSign) so Windows build succeeded. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,6 @@
     "productName": "ElectronReact",
     "appId": "org.erb.ElectronReact",
     "asar": true,
-    "afterSign": ".erb/scripts/notarize.js",
     "asarUnpack": "**\\*.{node,dll}",
     "files": [
       "dist",


### PR DESCRIPTION
It will show error when running npm run package --win because the setting is for mac, so i removed the afterSign setting to make things look nice without error. Even u dont remove the setting its not a big deal to other step i just remove the mac setting so it dont show error in console.